### PR TITLE
[Fix] Change link start writing button to /signup

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -87,7 +87,7 @@ export default function Header() {
 
       <div>
         <NavLink to="/signin" className="hidden sm:inline-block font-sans font-light text-lg mx-3 leading-loose hover:underline">Sign In</NavLink>
-        <NavLink to="/write" className="font-sans font-light text-lg text-gray-100 py-2 px-4 ml-3 bg-black rounded-full transform transition duration-300 hover:text-white hover:bg-gray-900">
+        <NavLink to="/signup" className="font-sans font-light text-lg text-gray-100 py-2 px-4 ml-3 bg-black rounded-full transform transition duration-300 hover:text-white hover:bg-gray-900">
           Start Writing
         </NavLink>
       </div>


### PR DESCRIPTION
Hi, Racmat

I found there some mistake when the user that not signup yet, which cannot go back to home page (/) cause of when clicking Start Writing button will go to (/writing) route, it will redirect to (/signup) page, so if go back (using back button of the browser) will go to (/writing) route and its condition is not logged yet, and then will be redirected (/signup) again.

So consider you accept my improvisation.

Thanks